### PR TITLE
apt warning fix

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,9 +13,8 @@
 
 - name: FLUENTD | Install required libs
   apt:
-    name: "{{ item }}"
+    name: "{{ fluentd_required_libs }}"
     update_cache: yes
-  with_items: "{{ fluentd_required_libs }}"
 
 - name: FLUENTD | Install fluentd gem
   gem:


### PR DESCRIPTION
Remove apt warning:
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply 
multiple items and specifying `name: "{{ item }}"`, please use `name: '{{ fluentd_required_libs }}'` and remove the loop. This feature 
will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

```