### PR TITLE
Remove yajl version pinning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 ---
 language: python
-python: "2.7.13"
+python: "3.6.10"
 sudo: required
 
 services:
   - docker
 install:
-  - pip install ansible==2.3.1.0
-  - pip install molecule==1.25.0
+  - pip install ansible==4.10.0
+  - pip install molecule==3.6.1
   - pip install docker
 script:
   - molecule test --driver docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+dist: focal
 language: python
 python: "3.6.10"
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
   - pip install molecule==3.6.1
   - pip install docker
 script:
-  - molecule test --driver docker
+  - molecule test --driver-name docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 install:
   - pip install ansible==4.10.0
   - pip install molecule==3.6.1
+  - pip install molecule-docker==1.1.0
   - pip install docker
 script:
   - molecule test --driver-name docker

--- a/molecule.yml
+++ b/molecule.yml
@@ -33,7 +33,7 @@ docker:
     - name: fluentd.cont
       ansible_groups:
         - fluentd
-      image: geerlingguy/docker-debian10-ansible
+      image: geerlingguy/docker-debian11-ansible
       image_version: latest
 
       privileged: True

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,12 +35,10 @@
   when:
     - ansible_distribution == "Amazon"
 
-# TODO Remove pinning yajl-ruby dependency version, after updating to Ubuntu 22.04
 - name: FLUENTD | Install fluentd gem yajl-ruby dependency
   gem:
     name: yajl-ruby
     state: present
-    version: "1.4.1"
     user_install: no
 
 - name: FLUENTD | Install fluentd gem


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

This PR removes yajl-ruby version pinning, so the role can be properly applied to Ubuntu 20.04+ hosts.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
