### PR TITLE
fix: force ffi to a version compatible with our ruby version

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -41,6 +41,13 @@
     state: present
     user_install: no
 
+- name: FLUENTD | Install fluentd gem yajl-ruby dependency
+  gem:
+    name: ffi
+    state: present
+    version: "1.17.0"
+    user_install: no
+
 - name: FLUENTD | Install fluentd gem
   gem:
     name: fluentd


### PR DESCRIPTION
fluentd plugin installation fails due to version incompatibilities between the `ffi` gem and the deployed version of ruby:

<img width="2465" alt="image" src="https://github.com/form3tech-oss/fluentd-role/assets/104838761/d548ea65-fdbf-437a-bc2b-fa0685296b50">

Fixing the gem version as required