### PR TITLE
feat: rely on OS package for dependencies gem

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -35,18 +35,11 @@
   when:
     - ansible_distribution == "Amazon"
 
-- name: FLUENTD | Install fluentd gem yajl-ruby dependency
-  gem:
-    name: yajl-ruby
-    state: present
-    user_install: no
-
-- name: FLUENTD | Install fluentd gem yajl-ruby dependency
-  gem:
-    name: ffi
-    state: present
-    version: "1.17.0"
-    user_install: no
+- name: FLUENTD | Install fluentd gem dependency
+  apt:
+    name: "{{ item }}"
+    update_cache: yes
+  with_items: [ "ruby-ffi", "ruby-ffi-jajl", "ruby-jajl"]
 
 - name: FLUENTD | Install fluentd gem
   gem:


### PR DESCRIPTION
Pinning the `ffi` gem version still not resolve the ruby version, relying on the OS packaged gem will ensure version are compatible.

Fix the following error:
<img width="2487" alt="image" src="https://github.com/form3tech-oss/fluentd-role/assets/104838761/cac107cc-ebe0-45ec-9872-e6f154316d37">

