### PR TITLE
fix: change include to include_role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,15 @@
 ---
-
 - name: FLUENTD | Install
-  include: install.yml
+  include_tasks: install.yml
   tags:
     - install
 
 - name: FLUENTD | Configure
-  include: config.yml
+  include_tasks: config.yml
   tags:
     - configure
 
 - name: FLUENTD | Service
-  include: service.yml
+  include_tasks: service.yml
   tags:
     - service


### PR DESCRIPTION
### Requirements
New version of ansible (10.7) has deprecated `include`, so it needs to be changed to `include_tasks`.

### Description of the Change
Change `include` to `include_tasks`

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
