### PR TITLE
fix: Install the fluentd service as well

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -24,12 +24,3 @@
     group: "{{ fluentd_group }}"
     mode: '0644'
   notify: restart fluentd
-
-- name: FLUENTD | Copy fluentd service config
-  template:
-    src: "{{ fluentd_service_template_path }}"
-    dest: /lib/systemd/system/fluentd.service
-    owner: "{{ fluentd_user }}"
-    group: "{{ fluentd_group }}"
-    mode: '0755'
-  notify: restart fluentd

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -64,3 +64,12 @@
     user_install: no
   with_items: "{{ fluentd_plugins }}"
   notify: restart fluentd
+
+- name: FLUENTD | Copy fluentd service config
+  template:
+    src: "{{ fluentd_service_template_path }}"
+    dest: /lib/systemd/system/fluentd.service
+    owner: "{{ fluentd_user }}"
+    group: "{{ fluentd_group }}"
+    mode: '0755'
+  notify: restart fluentd


### PR DESCRIPTION
### Requirements

During the installation, a handler restarts the service. If the service is not installed, the role fails.
### Description of the Change

Create the systemd service during installation and not configuration.