### PR TITLE
Use prebuild packages instead of gems

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # Installation variables
-fluentd_user: fluentd
-fluentd_group: fluentd
+fluentd_user: _fluentd
+fluentd_group: _fluentd
 fluentd_secondary_groups: []
 
 fluentd_version: "1.3.3"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,5 @@ fluentd_service_environment: [] # list of strings: ENV_NAME=value
 # Templates path
 fluentd_playbook_templates_path: "{{ playbook_dir }}/templates/fluentd"
 fluentd_service_template_path: fluentd/fluentd.service.j2
+
+fluentd_deb_repo_url: "https://packages.treasuredata.com/lts/5/ubuntu/jammy/pool/contrib/f/fluent-lts-apt-source/fluent-lts-apt-source_2025.1.8-1_all.deb"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -19,7 +19,7 @@
 - name: FLUENTD | Copy server config
   template:
     src: "{{ fluentd_playbook_templates_path }}/fluent.conf.j2"
-    dest: "{{ fluentd_conf_path }}/fluent.conf"
+    dest: "{{ fluentd_conf_path }}/fluentd.conf"
     owner: "{{ fluentd_user }}"
     group: "{{ fluentd_group }}"
     mode: '0644'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,3 +8,4 @@
 - name: Install fluentd package
   ansible.builtin.apt:
     name: fluent-package
+    update_cache: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,5 +16,6 @@
     version: "{{ item.version }}"
     state: present
     user_install: no
+    executable: "/usr/sbin/fluent-gem"
   with_items: "{{ fluentd_plugins }}"
   notify: restart fluentd

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,3 +9,12 @@
   ansible.builtin.apt:
     name: fluent-package
     update_cache: yes
+
+- name: FLUENTD | Install fluentd plugin gems
+  gem:
+    name: "{{ item.name }}"
+    version: "{{ item.version }}"
+    state: present
+    user_install: no
+  with_items: "{{ fluentd_plugins }}"
+  notify: restart fluentd

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,75 +1,10 @@
 ---
 
-- name: FLUENTD | Create fluentd group
-  group:
-    name: "{{ fluentd_group }}"
-    state: present
-
-- name: FLUENTD | Create fluentd user
-  user:
-    name: "{{ fluentd_user }}"
-    group: "{{ fluentd_group }}"
-    groups: "{{ fluentd_secondary_groups }}"
-
-- name: FLUENTD | Install required libs on Debian
-  apt:
-    name: "{{ item }}"
+- name: Install repo
+  ansible.builtin.apt:
+    deb: "{{ fluentd_deb_repo_url }}"
     update_cache: yes
-  with_items: ["gcc", "make", "ruby", "ruby-dev"]
-  when:
-    - ansible_distribution == "Debian"
 
-- name: FLUENTD | Install required libs on Ubuntu
-  apt:
-    name: "{{ item }}"
-    update_cache: yes
-  with_items: ["gcc", "make", "ruby", "ruby-dev"]
-  when:
-    - ansible_distribution == "Ubuntu"
-
-- name: FLUENTD | Install required libs on Amazon
-  yum:
-    name: "{{ item }}"
-    update_cache: yes
-  with_items: ["gcc", "make", "ruby", "ruby-devel"]
-  when:
-    - ansible_distribution == "Amazon"
-
-- name: FLUENTD | Install fluentd gem yajl-ruby dependency
-  gem:
-    name: yajl-ruby
-    state: present
-    user_install: no
-
-- name: FLUENTD | Install fluentd gem ffi dependency
-  gem:
-    name: ffi
-    state: present
-    version: "1.16.3"
-    user_install: no
-
-- name: FLUENTD | Install fluentd gem
-  gem:
-    name: fluentd
-    state: present
-    version: "{{ fluentd_version }}"
-    user_install: no
-  notify: restart fluentd
-
-- name: FLUENTD | Install fluentd plugin gems
-  gem:
-    name: "{{ item.name }}"
-    version: "{{ item.version }}"
-    state: present
-    user_install: no
-  with_items: "{{ fluentd_plugins }}"
-  notify: restart fluentd
-
-- name: FLUENTD | Copy fluentd service config
-  template:
-    src: "{{ fluentd_service_template_path }}"
-    dest: /lib/systemd/system/fluentd.service
-    owner: "{{ fluentd_user }}"
-    group: "{{ fluentd_group }}"
-    mode: '0755'
-  notify: restart fluentd
+- name: Install fluentd package
+  ansible.builtin.apt:
+    name: fluent-package


### PR DESCRIPTION
### Requirements

Use newer packages, so that it's possible to install and configure separately

### Description of the Change

Instead of installation from `gem` usage `ubuntu` packages.

